### PR TITLE
Fix style issue when pressing enter on answered multiple-choice

### DIFF
--- a/frontend/src/pages/TestView.vue
+++ b/frontend/src/pages/TestView.vue
@@ -360,8 +360,6 @@ function submitAnswer(d: number = -1) {
     }
 }
 function checkAnswer(d: number = -1) {
-    rightAnswer.value = []
-    wrongAnswer.value = []
     let checkProblemId = d
     if (d !== -1)
         nowAnswer.value = answerList.value[d];
@@ -369,6 +367,8 @@ function checkAnswer(d: number = -1) {
         checkProblemId = nowProblemId.value
     if (problemState.value[checkProblemId] > 1)
         return
+    rightAnswer.value = []
+    wrongAnswer.value = []
     let flag = true
     if (problemState.value[checkProblemId] === -1)
         flag = false


### PR DESCRIPTION
## Summary
- avoid clearing answer status if the current question is already submitted

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_684b898ed54483218847e6a0ef12c7fb